### PR TITLE
데이터베이스 테이블 추가와 수정

### DIFF
--- a/models/init-models.js
+++ b/models/init-models.js
@@ -7,6 +7,8 @@ var _t_question = require("./t_question");
 var _t_review = require("./t_review");
 var _t_review_image = require("./t_review_image");
 var _t_user = require("./t_user");
+var _t_seller = require("./t_seller");
+var _t_user_bussiness_type = require("./t_user_bussiness_type");
 
 function initModels(sequelize) {
   var t_address = _t_address(sequelize, DataTypes);
@@ -17,6 +19,8 @@ function initModels(sequelize) {
   var t_review = _t_review(sequelize, DataTypes);
   var t_review_image = _t_review_image(sequelize, DataTypes);
   var t_user = _t_user(sequelize, DataTypes);
+  var t_seller = _t_seller(sequelize, DataTypes);
+  var t_user_bussiness_type = _t_user_bussiness_type(sequelize, DataTypes);
 
   t_order.belongsTo(t_address, { as: "address", foreignKey: "address_id"});
   t_address.hasMany(t_order, { as: "t_orders", foreignKey: "address_id"});
@@ -39,14 +43,23 @@ function initModels(sequelize) {
 
   t_address.belongsTo(t_user, { as: "user", foreignKey: "user_id"});
   t_user.hasMany(t_address, { as: "t_addresses", foreignKey: "user_id"});
+
   t_order.belongsTo(t_user, { as: "user", foreignKey: "user_id"});
   t_user.hasMany(t_order, { as: "t_orders", foreignKey: "user_id"});
-  t_product.belongsTo(t_user, { as: "register_user", foreignKey: "register_user_id"});
-  t_user.hasMany(t_product, { as: "t_products", foreignKey: "register_user_id"});
+
+  t_product.belongsTo(t_seller, { as: "seller", foreignKey: "seller_id"});
+  t_seller.hasMany(t_product, { as: "t_products", foreignKey: "seller_id"});
+
   t_question.belongsTo(t_user, { as: "user", foreignKey: "user_id"});
+
   t_user.hasMany(t_question, { as: "t_questions", foreignKey: "user_id"});
   t_review.belongsTo(t_user, { as: "user", foreignKey: "user_id"});
   t_user.hasMany(t_review, { as: "t_reviews", foreignKey: "user_id"});
+
+  t_user_bussiness_type.belongsTo(t_user, { as: "user", foreignKey: "user_id"});
+  t_user.hasMany(t_user_bussiness_type, { as: "t_user_bussiness_types", foreignKey: "user_id"});
+
+
 
   return {
     t_address,
@@ -57,6 +70,8 @@ function initModels(sequelize) {
     t_review,
     t_review_image,
     t_user,
+    t_seller,
+    t_user_bussiness_type,
   };
 }
 module.exports = initModels;

--- a/models/t_product.js
+++ b/models/t_product.js
@@ -12,12 +12,12 @@ class t_product extends Sequelize.Model {
       allowNull: false,
       primaryKey: true
     },
-    register_user_id: {
+    seller_id: {
       type: DataTypes.INTEGER.UNSIGNED,
       allowNull: true,
       defaultValue: 0,
       references: {
-        model: 't_user',
+        model: 't_seller',
         key: 'id'
       }
     },
@@ -76,10 +76,10 @@ class t_product extends Sequelize.Model {
         ]
       },
       {
-        name: "FK_t_product_t_user",
+        name: "FK_t_product_t_seller",
         using: "BTREE",
         fields: [
-          { name: "register_user_id" },
+          { name: "seller_id" },
         ]
       },
     ]

--- a/models/t_seller.js
+++ b/models/t_seller.js
@@ -1,9 +1,9 @@
 const Sequelize = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
-  return t_user.init(sequelize, DataTypes);
+  return t_seller.init(sequelize, DataTypes);
 }
 
-class t_user extends Sequelize.Model {
+class t_seller extends Sequelize.Model {
   static init(sequelize, DataTypes) {
   super.init({
     id: {
@@ -12,7 +12,7 @@ class t_user extends Sequelize.Model {
       allowNull: false,
       primaryKey: true
     },
-    user_name: {
+    seller_name: {
       type: DataTypes.STRING(20),
       allowNull: false
     },
@@ -20,22 +20,18 @@ class t_user extends Sequelize.Model {
       type: DataTypes.STRING(20),
       allowNull: false
     },
-    user_email: {
+    seller_email: {
       type: DataTypes.STRING(1024),
       allowNull: false,
-      unique: "user_email"
+      unique: "seller_email"
     },
-    user_password: {
+    seller_password: {
       type: DataTypes.STRING(1024),
       allowNull: false
-    },
-    user_point_money: {
-      type: DataTypes.INTEGER.UNSIGNED,
-      allowNull: false
-    }
+    },   
   }, {
     sequelize,
-    tableName: 't_user',
+    tableName: 't_seller',
     timestamps: true,
     paranoid: true,
     indexes: [
@@ -48,15 +44,15 @@ class t_user extends Sequelize.Model {
         ]
       },
       {
-        name: "user_email",
+        name: "seller_email",
         unique: true,
         using: "BTREE",
         fields: [
-          { name: "user_email" },
+          { name: "seller_email" },
         ]
       },
     ]
   });
-  return t_user;
+  return t_seller;
   }
 }

--- a/models/t_user_bussiness_type.js
+++ b/models/t_user_bussiness_type.js
@@ -1,0 +1,52 @@
+const Sequelize = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  return t_user_bussiness_type.init(sequelize, DataTypes);
+}
+
+class t_user_bussiness_type extends Sequelize.Model {
+  static init(sequelize, DataTypes) {
+  super.init({
+    id: {
+      autoIncrement: true,
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      primaryKey: true
+    },
+    user_id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      references: {
+        model: 't_user',
+        key: 'id'
+      }
+    },
+    bussiness_type: {
+        type: DataTypes.INTEGER.UNSIGNED,
+        allowNull: false,
+        comment: "1-한식, 2-일식, 3-중식, 4-서양식" 
+    }
+  }, {
+    sequelize,
+    tableName: 't_user_bussiness_type',
+    timestamps: false,
+    indexes: [
+      {
+        name: "PRIMARY",
+        unique: true,
+        using: "BTREE",
+        fields: [
+          { name: "id" },
+        ]
+      },
+      {
+        name: "FK_t_user_bussiness_type_t_user",
+        using: "BTREE",
+        fields: [
+          { name: "user_id" },
+        ]
+      },
+    ]
+  });
+  return t_user_bussiness_type;
+  }
+}


### PR DESCRIPTION
1. 판매자테이블 추가
2. 사용자 업종 테이블 추가
3. user테이블에 생성날짜컬럼, 수정 날짜 컬럼, 삭제 날짜 컬럼 추가 / 유저이메일과 유저페스워드 컬럼의 데이터 길이를 40byte에서 1024byte로 확장
4. product테이블의 기존 register_user_id칼럼을 삭제하고 seller테이블의 id와 릴레이션을 맺는 seller_id컬럼을 추가
5. init-models.js에 새로 추가한 테이블과 수정한 테이블의 정보를 입력