### PR TITLE
라우터의 앞부분 url을 /api/product에서 /api로 변경

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,7 @@ const productroutes = require('./routes/product.js');
 
 app.use('/api', routes)
 app.use('/api', authRoutes)
-app.use('/api/product', productroutes)
+app.use('/api', productroutes)
 
 app.listen(3000, (err) => {
   if (err) {


### PR DESCRIPTION
라우터의 앞부분 url을 /api/product에서 /api로 변경