### PR TITLE
💄 address.js 기존 라우터수정, 새로운 라우터 작성

### DIFF
--- a/routes/address.js
+++ b/routes/address.js
@@ -9,13 +9,13 @@ router.post('/address/default', async (req, res) => {
     try{
         let useraddress = await models.t_address.findAll({ 
             where : { 
-                id : req.body.userid,
+                user_id : req.body.userid,
                 default_address : req.body.default_address
             }   
         })
         res.json({
             success : true,
-            useraddress
+            useraddress : useraddress[0].dataValues
         })
     } catch (err) {
         res.status(500).json({
@@ -46,26 +46,109 @@ router.post('/address/list', async (req, res) => {
     }
 })
 
-// 신규배송지를 저장
+// 결제페이지에서 신규배송지를 저장
 router.post('/address/save', async (req, res) => {
-    console.log(req.body);
+    // console.log(req.body);
     try {
-        let newaddress = await models.t_address.create({
-            user_id : req.body.user_id,
-            receiver : req.body.receiver,
-            address_name : req.body.address_name,
-            post_code : req.body.post_code,
-            address : req.body.address,
-            detailed_address : req.body.detail_adress,
-            phonenumber : req.body.phonenumber,
-            address_list : req.body.address_list,
-            default_address : req.body.default_address
+        if(req.body.default_address){
+            models.t_address.update({
+                user_id : req.body.user_id,
+                receiver : req.body.receiver,
+                address_name : req.body.address_name,
+                post_code : req.body.post_code,
+                address : req.body.address,
+                detailed_address : req.body.detail_adress,
+                phonenumber : req.body.phonenumber,
+                address_list : true,
+                default_address : req.body.default_address
+            }, {
+                where : {
+                    default_address : 1,
+                    user_id : req.body.user_id
+                }
+            })
+            .catch(err => {
+                console.log(err)
+            })
+            // console.log(newaddress)
+            res.json({
+                success : true
+            })
+        } else {
+            let newaddress = await models.t_address.create({
+                user_id : req.body.user_id,
+                receiver : req.body.receiver,
+                address_name : req.body.address_name,
+                post_code : req.body.post_code,
+                address : req.body.address,
+                detailed_address : req.body.detail_adress,
+                phonenumber : req.body.phonenumber,
+                address_list : req.body.address_list,
+                default_address : req.body.default_address
+            })
+            console.log(newaddress.dataValues.id)
+            res.json({
+                success : true,
+                address_id : newaddress.dataValues.id
+            })
+        }
+        
+    } catch (err) {
+        res.status(500).json({
+            success : false,
+            message : err.message
         })
-        console.log(newaddress.dataValues.id)
-        res.json({
-            success : true,
-            address_id : newaddress.dataValues.id
-        })
+    }
+})
+
+// 배송지관리페이지에서 신규배송지를 저장
+router.post('/addresslist/save', async (req, res) => {
+    // console.log(req.body);
+    try {
+        if(req.body.default_address){
+            models.t_address.update({
+                user_id : req.body.user_id,
+                receiver : req.body.receiver,
+                address_name : req.body.address_name,
+                post_code : req.body.post_code,
+                address : req.body.address,
+                detailed_address : req.body.detail_adress,
+                phonenumber : req.body.phonenumber,
+                address_list : req.body.address_list,
+                default_address : req.body.default_address
+            }, {
+                where : {
+                    default_address : 1,
+                    user_id : req.body.user_id
+                }
+            })
+            .catch(err => {
+                console.log(err)
+            })
+            // console.log(newaddress)
+            res.json({
+                success : true
+            })
+        } else {
+            models.t_address.create({
+                user_id : req.body.user_id,
+                receiver : req.body.receiver,
+                address_name : req.body.address_name,
+                post_code : req.body.post_code,
+                address : req.body.address,
+                detailed_address : req.body.detail_adress,
+                phonenumber : req.body.phonenumber,
+                address_list : req.body.address_list,
+                default_address : req.body.default_address
+            })
+            .catch(err => {
+                console.log(err)
+            })
+            res.json({
+                success : true              
+            })
+        }
+        
     } catch (err) {
         res.status(500).json({
             success : false,


### PR DESCRIPTION
1. 사용자의 기본배송지를 가져오는 라우터의 쿼리문이 잘못 작성된 부분 수정
2. 기존의 신규배송지 저장 라우터를 결제페이지에서 신규배송지를 저정하는 라우터로 변경, 배송지관리 페이지에서 신규배송지를 저장하는 라우터 작성(이렇게 나눈 이유는 결제페이지에서 긴규배송지를 저장하면 클라이언트로 저장한 배송지의 id값을 전달해야하는데 배송지관리페이지에서 신규배송지를 저장할 경우 그럴 필요가 없어서 나눴음)
3. 결제페이지에서 신규배송지를 저장하는 라우터, 배송지관리 페이지에서 신규배송지를 저장하는 라우터 둘 다 기본배송지로 설정버튼이 true면 기존의 기본배송지를 수정하는 방향으로 작성